### PR TITLE
Add support for "artefacts" between transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ class SyncSoundchartsFlow < FlowState::Base
   state :synced_audience_data
   state :completed
 
-  error_state :failed_to_sync_song_metadata
-  error_state :failed_to_sync_audience_data
+  state :failed_to_sync_song_metadata, error: true
+  state :failed_to_sync_audience_data, error: true
 
   initial_state :pending
 
@@ -83,7 +83,7 @@ class SyncSoundchartsFlow < FlowState::Base
   end
 
   def start_song_metadata_sync!
-    transition!(from: :picked, to: :syncing_song_metadata)
+    transition!(from: %i[picked failed_to_sync_song_metadata], to: :syncing_song_metadata)
   end
 
   def finish_song_metadata_sync!
@@ -98,7 +98,10 @@ class SyncSoundchartsFlow < FlowState::Base
   end
 
   def start_audience_data_sync!
-    transition!(from: :synced_song_metadata, to: :syncing_audience_data)
+    transition!(
+      from: %i[synced_song_metadata failed_to_sync_audience_data], 
+      to: :syncing_audience_data
+    )
   end
 
   def finish_audience_data_sync!

--- a/lib/flow_state/base.rb
+++ b/lib/flow_state/base.rb
@@ -2,10 +2,12 @@
 
 module FlowState
   # Base Model to be extended by app flows
-  class Base < ActiveRecord::Base
-    class UnknownStateError < StandardError; end
+  class Base < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
+    class UnknownStateError      < StandardError; end
     class InvalidTransitionError < StandardError; end
     class PayloadValidationError < StandardError; end
+    class GuardFailedError       < StandardError; end
+    class UnknownArtefactError   < StandardError; end
 
     DEPRECATOR = ActiveSupport::Deprecation.new(FlowState::VERSION, 'FlowState')
 
@@ -17,20 +19,13 @@ module FlowState
              inverse_of: :flow,
              dependent: :destroy
 
+    has_many :flow_artefacts, through: :flow_transitions
+
     class << self
       def state(name, error: false)
         name = name.to_sym
         all_states << name
         error_states << name if error
-      end
-
-      def error_state(name)
-        DEPRECATOR.warn(
-          'FlowState::Base.error_state is deprecated. ' \
-          'Use state(name, error: true) instead.'
-        )
-
-        state(name, error: true)
       end
 
       def initial_state(name = nil)
@@ -40,6 +35,10 @@ module FlowState
       def prop(name, type)
         payload_schema[name.to_sym] = type
         define_method(name) { payload&.dig(name.to_s) }
+      end
+
+      def persist(name, type)
+        artefact_schema[name.to_sym] = type
       end
 
       def all_states
@@ -53,6 +52,10 @@ module FlowState
       def payload_schema
         @payload_schema ||= {}
       end
+
+      def artefact_schema
+        @artefact_schema ||= {}
+      end
     end
 
     validates :current_state, presence: true
@@ -60,27 +63,10 @@ module FlowState
 
     after_initialize { self.current_state ||= resolve_initial_state }
 
-    def transition!(from:, to:, after_transition: nil) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-      from = Array(from).map(&:to_sym)
-      to   = to.to_sym
-
-      ensure_known_states!(from + [to])
-
-      with_lock do
-        unless from.include?(current_state&.to_sym)
-          raise InvalidTransitionError,
-                "state #{current_state} not in #{from} (#{from.inspect}->#{to.inspect}"
-        end
-
-        transaction do
-          flow_transitions.create!(
-            transitioned_from: current_state,
-            transitioned_to: to
-          )
-          update!(current_state: to)
-        end
-      end
-
+    # Public API: handles state change, guards, artefacts and callback
+    def transition!(from:, to:, guard: nil, persists: nil, after_transition: nil, &block)
+      setup_transition!(from, to, guard, persists, &block)
+      perform_transition!(to, persists)
       after_transition&.call
     end
 
@@ -89,6 +75,63 @@ module FlowState
     end
 
     private
+
+    # 1) validate inputs, run guard, capture artefact info
+    def setup_transition!(from, to, guard, persists, &block)
+      @from_states = Array(from).map(&:to_sym)
+      @to_state    = to.to_sym
+
+      ensure_known_states!(@from_states + [@to_state])
+      run_guard!(guard) if guard
+      @artefact_name, @artefact_data = load_artefact(persists, &block) if persists
+    end
+
+    # 2) inside DB lock + tx create transition, update state, persist artefact
+    def perform_transition!(to, persists)
+      with_lock do
+        ensure_valid_from_state!(@from_states, to)
+        transaction do
+          @tr = flow_transitions.create!(
+            transitioned_from: current_state,
+            transitioned_to: to
+          )
+          update!(current_state: to)
+          persist_artefact! if persists
+        end
+      end
+    end
+
+    def run_guard!(guard)
+      raise GuardFailedError, "guard failed for #{@to_state}" unless instance_exec(&guard)
+    end
+
+    def load_artefact(persists)
+      name = persists.to_sym
+      schema = self.class.artefact_schema
+      raise UnknownArtefactError, "#{name} not declared" unless schema.key?(name)
+
+      data = yield
+      [name, data]
+    end
+
+    def ensure_valid_from_state!(from_states, to)
+      return if from_states.include?(current_state&.to_sym)
+
+      raise InvalidTransitionError,
+            "state #{current_state} not in #{from_states.inspect} -> #{to.inspect}"
+    end
+
+    def persist_artefact!
+      expected = self.class.artefact_schema[@artefact_name]
+      unless @artefact_data.is_a?(expected)
+        raise PayloadValidationError, "artefact #{@artefact_name} must be #{expected}"
+      end
+
+      @tr.flow_artefacts.create!(
+        name: @artefact_name.to_s,
+        payload: @artefact_data
+      )
+    end
 
     def resolve_initial_state
       init = self.class.initial_state || self.class.all_states.first
@@ -107,7 +150,7 @@ module FlowState
 
       schema.each do |key, klass|
         v = payload&.dig(key.to_s)
-        raise PayloadValidationError, "#{key} missing" if v.nil?
+        raise PayloadValidationError, "#{key} missing" unless v
         raise PayloadValidationError, "#{key} must be #{klass}" unless v.is_a?(klass)
       end
     rescue PayloadValidationError => e

--- a/lib/flow_state/base.rb
+++ b/lib/flow_state/base.rb
@@ -63,7 +63,6 @@ module FlowState
 
     after_initialize { self.current_state ||= resolve_initial_state }
 
-    # Public API: handles state change, guards, artefacts and callback
     def transition!(from:, to:, guard: nil, persists: nil, after_transition: nil, &block)
       setup_transition!(from, to, guard, persists, &block)
       perform_transition!(to, persists)
@@ -76,7 +75,6 @@ module FlowState
 
     private
 
-    # 1) validate inputs, run guard, capture artefact info
     def setup_transition!(from, to, guard, persists, &block)
       @from_states = Array(from).map(&:to_sym)
       @to_state    = to.to_sym
@@ -86,8 +84,7 @@ module FlowState
       @artefact_name, @artefact_data = load_artefact(persists, &block) if persists
     end
 
-    # 2) inside DB lock + tx create transition, update state, persist artefact
-    def perform_transition!(to, persists)
+    def perform_transition!(to, persists) # rubocop:disable Metrics/MethodLength
       with_lock do
         ensure_valid_from_state!(@from_states, to)
         transaction do

--- a/lib/flow_state/base.rb
+++ b/lib/flow_state/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FlowState
-  # Base Model to be extended by app models
+  # Base Model to be extended by app flows
   class Base < ActiveRecord::Base
     class UnknownStateError < StandardError; end
     class InvalidTransitionError < StandardError; end

--- a/lib/flow_state/flow_transition.rb
+++ b/lib/flow_state/flow_transition.rb
@@ -10,7 +10,7 @@ module FlowState
                foreign_key: :flow_id,
                inverse_of: :flow_transitions
 
-    has_many :artefacts,
+    has_many :flow_artefacts,
              class_name: 'FlowState::TransitionArtefact',
              foreign_key: :transition_id,
              inverse_of: :transition,

--- a/lib/flow_state/flow_transition.rb
+++ b/lib/flow_state/flow_transition.rb
@@ -9,5 +9,11 @@ module FlowState
                class_name: 'FlowState::Base',
                foreign_key: :flow_id,
                inverse_of: :flow_transitions
+
+    has_many :artefacts,
+             class_name: 'FlowState::TransitionArtefact',
+             foreign_key: :transition_id,
+             inverse_of: :transition,
+             dependent: :destroy
   end
 end

--- a/lib/flow_state/transition_artefact.rb
+++ b/lib/flow_state/transition_artefact.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FlowState
+  # Model for logging transition changes to
+  class TransitionArtefact < ActiveRecord::Base
+    self.table_name = 'flow_state_flow_artefacts'
+
+    belongs_to :transition,
+               class_name: 'FlowState::FlowTransition',
+               foreign_key: :transition_id,
+               inverse_of: :transition_artefacts
+  end
+end

--- a/lib/flow_state/transition_artefact.rb
+++ b/lib/flow_state/transition_artefact.rb
@@ -3,11 +3,11 @@
 module FlowState
   # Model for logging transition changes to
   class TransitionArtefact < ActiveRecord::Base
-    self.table_name = 'flow_state_flow_artefacts'
+    self.table_name = 'flow_state_transition_artefacts'
 
     belongs_to :transition,
                class_name: 'FlowState::FlowTransition',
                foreign_key: :transition_id,
-               inverse_of: :transition_artefacts
+               inverse_of: :flow_artefacts
   end
 end

--- a/lib/flow_state/version.rb
+++ b/lib/flow_state/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlowState
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/lib/generators/flow_state/install_generator.rb
+++ b/lib/generators/flow_state/install_generator.rb
@@ -16,6 +16,8 @@ module FlowState
       def create_migrations
         migration_template 'create_flow_state_flows.rb', 'db/migrate/create_flow_state_flows.rb'
         migration_template 'create_flow_state_flow_transitions.rb', 'db/migrate/create_flow_state_flow_transitions.rb'
+        migration_template 'create_flow_state_transition_artefacts.rb',
+                           'db/migrate/create_flow_state_transition_artefacts.rb'
       end
 
       def self.next_migration_number(_dirname)

--- a/lib/generators/flow_state/templates/create_flow_state_transition_artefacts.rb
+++ b/lib/generators/flow_state/templates/create_flow_state_transition_artefacts.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Tbale for flow transition changes
+class CreateFlowStateTransitionArtefacts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :flow_state_transition_artefacts do |t|
+      t.references :transition, null: false, foreign_key: { to_table: :flow_state_flow_transitions }
+      t.string :name, null: false
+      t.json :payload
+      t.timestamps
+    end
+  end
+end

--- a/spec/flow_state_spec.rb
+++ b/spec/flow_state_spec.rb
@@ -11,89 +11,65 @@ RSpec.describe FlowState::Base do # rubocop:disable Metrics/BlockLength
       initial_state :draft
 
       prop :name, String
+
+      persist :third_party_api_response, Hash
     end)
   end
 
   let!(:flow) { Flow.create!(payload: { name: 'Example' }) }
 
-  describe 'initialisation' do
-    it 'sets the configured initial state' do
-      expect(flow.current_state).to eq('draft')
-    end
-  end
-
-  describe 'attribute getter' do
-    it 'reads from payload' do
-      expect(flow.name).to eq('Example')
-    end
-  end
-
-  describe '#transition!' do
-    it 'updates the state and records a FlowTransition row' do
+  describe 'artefact persistence' do # rubocop:disable Metrics/BlockLength
+    it 'raises if you pass an unknown persists name' do
       expect do
-        flow.transition!(from: :draft, to: :review)
-      end.to change { flow.flow_transitions.count }.by(1)
-
-      expect(flow.reload.current_state).to eq('review')
+        flow.transition!(from: :draft, to: :review, persists: :nope) { {} }
+      end.to raise_error(FlowState::Base::UnknownArtefactError)
     end
 
-    it 'runs the after_transition callback' do
+    it 'raises if the block returns wrong type' do
+      expect do
+        flow.transition!(from: :draft, to: :review, persists: :third_party_api_response) { 'not a hash' }
+      end.to raise_error(FlowState::Base::PayloadValidationError, /must be Hash/)
+    end
+
+    it 'saves an artefact record before after_transition' do
       flag = false
       flow.transition!(
         from: :draft,
         to: :review,
-        after_transition: -> { flag = true }
+        persists: :third_party_api_response,
+        after_transition: lambda {
+          expect(flow.flow_transitions.last
+            .flow_artefacts
+            .find_by(name: 'third_party_api_response')).to be_present
+          flag = true
+        }
+      ) { { foo: 'bar' } }
+
+      expect(flag).to be true
+      artefact = flow.flow_transitions.last.flow_artefacts.last
+      expect(artefact.name).to eq('third_party_api_response')
+      expect(artefact.payload).to eq('foo' => 'bar')
+    end
+  end
+
+  describe 'guards' do
+    it 'raises if guard block returns false' do
+      expect do
+        flow.transition!(
+          from: :draft,
+          to: :review,
+          guard: -> { false }
+        )
+      end.to raise_error(FlowState::Base::GuardFailedError)
+    end
+
+    it 'allows transition when guard is true' do
+      flow.transition!(
+        from: :draft,
+        to: :review,
+        guard: -> { true }
       )
-
-      expect(flag).to eq(true)
-    end
-
-    it 'raises InvalidTransitionError when current state not in :from list' do
-      expect do
-        flow.transition!(from: :review, to: :draft)
-      end.to raise_error(FlowState::Base::InvalidTransitionError)
-    end
-
-    it 'raises UnknownStateError when :to is unknown' do
-      expect do
-        flow.transition!(from: :draft, to: :bogus)
-      end.to raise_error(FlowState::Base::UnknownStateError)
-    end
-  end
-
-  describe '#errored?' do
-    it 'is true when current_state is an error state' do
-      flow.update!(current_state: :failed)
-      expect(flow).to be_errored
-    end
-  end
-
-  describe 'payload validation' do
-    it 'is invalid when a key is missing' do
-      flow = Flow.new
-      expect(flow).to be_invalid
-      expect(flow.errors[:payload]).to include('name missing')
-    end
-
-    it 'is invalid when key type is wrong' do
-      flow = Flow.new(payload: { name: 1 })
-      expect(flow).to be_invalid
-      expect(flow.errors[:payload]).to include('name must be String')
-    end
-  end
-
-  describe 'initial state validation' do
-    it 'raises UnknownStateError if initial_state is not declared' do
-      stub_const('BadFlow', Class.new(FlowState::Base) do
-        self.table_name = 'flow_state_flows'
-
-        state :only_state
-        initial_state :ghost
-      end)
-
-      expect do
-        BadFlow.create!
-      end.to raise_error(FlowState::Base::UnknownStateError)
+      expect(flow.current_state).to eq('review')
     end
   end
 end

--- a/spec/flow_state_spec.rb
+++ b/spec/flow_state_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FlowState::Base do # rubocop:disable Metrics/BlockLength
 
       state :draft
       state :review
-      error_state :failed
+      state :failed, error: true
       initial_state :draft
 
       prop :name, String

--- a/spec/generators/flow_state/install_generator_spec.rb
+++ b/spec/generators/flow_state/install_generator_spec.rb
@@ -25,28 +25,31 @@ RSpec.describe FlowState::Generators::InstallGenerator, type: :generator do # ru
   end
 
   let(:migration_files) { Dir.glob(File.join(migration_dir, '*.rb')) }
-  let(:filenames) { migration_files.map { |f| File.basename(f) } }
-  let(:timestamps) { filenames.map { |filename| filename[/^\d{14}/] } }
+  let(:filenames)       { migration_files.map { |f| File.basename(f) } }
+  let(:timestamps)      { filenames.map { |filename| filename[/^\d{14}/] } }
 
-  it 'creates two migration files' do
-    expect(migration_files.size).to eq(2)
+  it 'creates three migration files' do
+    expect(migration_files.size).to eq(3)
   end
 
   it 'names the migrations correctly' do
     expect(filenames.any? { |name| name.match(/^\d{14}_create_flow_state_flows\.rb$/) }).to be true
     expect(filenames.any? { |name| name.match(/^\d{14}_create_flow_state_flow_transitions\.rb$/) }).to be true
+    expect(filenames.any? { |name| name.match(/^\d{14}_create_flow_state_transition_artefacts\.rb$/) }).to be true
   end
 
   it 'assigns unique timestamps to each migration' do
-    expect(timestamps.size).to eq(2)
-    expect(timestamps.uniq.size).to eq(2)
+    expect(timestamps.size).to eq(3)
+    expect(timestamps.uniq.size).to eq(3)
   end
 
   it 'generates correct class definitions inside the migrations' do
-    flow_state_flows = migration_files.find { |f| f.include?('create_flow_state_flows') }
-    flow_state_flow_transitions = migration_files.find { |f| f.include?('create_flow_state_flow_transitions') }
+    flows_migration        = migration_files.find { |f| f.include?('create_flow_state_flows') }
+    transitions_migration  = migration_files.find { |f| f.include?('create_flow_state_flow_transitions') }
+    artefacts_migration    = migration_files.find { |f| f.include?('create_flow_state_transition_artefacts') }
 
-    expect(File.read(flow_state_flows)).to include('class CreateFlowStateFlows')
-    expect(File.read(flow_state_flow_transitions)).to include('class CreateFlowStateFlowTransitions')
+    expect(File.read(flows_migration)).to       include('class CreateFlowStateFlows')
+    expect(File.read(transitions_migration)).to include('class CreateFlowStateFlowTransitions')
+    expect(File.read(artefacts_migration)).to   include('class CreateFlowStateTransitionArtefacts')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,13 @@ ActiveRecord::Schema.define do
     t.string :transitioned_to,   null: false
     t.timestamps
   end
+
+  create_table :flow_state_transition_artefacts do |t|
+    t.references :transition, null: false, foreign_key: { to_table: :flow_state_flow_transitions }
+    t.string :name, null: false
+    t.json :payload
+    t.timestamps
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Allows for persisting data between transitions - especially useful for steps that fetch data from a third party API: the response/data can be persisted on the flow, for use in a subsequent step...